### PR TITLE
adding neon provider from kislerdm

### DIFF
--- a/providers.json
+++ b/providers.json
@@ -7,8 +7,7 @@
   {
     "name": "neon",
     "terraform": "kislerdm/neon",
-    "version": "0.6.3",
-    "suffix": "5"
+    "version": "0.6.3"
   },
   {
     "name": "supabase",

--- a/providers.json
+++ b/providers.json
@@ -6,9 +6,9 @@
   },
   {
     "name": "neon",
-    "terraform": "terraform-community-providers/neon",
-    "version": "0.1.8",
-    "suffix": "4"
+    "terraform": "kislerdm/neon",
+    "version": "0.6.3",
+    "suffix": "5"
   },
   {
     "name": "supabase",


### PR DESCRIPTION
the neon provider created by kislerdm (https://github.com/kislerdm/terraform-provider-neon) is more widely used, and also sponsored by neon: https://neon.tech/docs/reference/terraform.
