### PR TITLE
try different turso

### DIFF
--- a/providers.json
+++ b/providers.json
@@ -22,7 +22,7 @@
   },
   {
     "name": "turso",
-    "terraform": "registry.terraform.io/jpedroh/turso",
-    "version": "0.2.1"
+    "terraform": "registry.terraform.io/celest-dev/turso",
+    "version": "0.2.3"
   }
 ]


### PR DESCRIPTION
The last one wouldn't work:
```
default_0_2_1 pulumi:providers:turso
   pulumi:providers:turso resource 'default_0_2_1' has a problem: Provider is missing a required configuration key, try `pulumi config set turso:apiToken`: The API token
 to authenticate with Turso API
 ```
Maybe it was a provider issue? This one also seems more widely used.