### PR TITLE
feat: add singlestore provider

### DIFF
--- a/metadata/singlestore.toml
+++ b/metadata/singlestore.toml
@@ -1,0 +1,3 @@
+name = "singlestore"
+terraform = "registry.terraform.io/singlestore-labs/singlestoredb"
+version = "0.1.0-alpha.10"


### PR DESCRIPTION
This adds the Terraform provider for [SingleStore](https://registry.terraform.io/providers/singlestore-labs/singlestoredb/latest).

The `generate.ts` script doesn't work for me because the postinstall script runs before the tsconfig is updated, but I'm assuming this is just a problem with my local environment.