### PR TITLE
feat: singlestore provider (and build error fix)

### DIFF
--- a/generate.ts
+++ b/generate.ts
@@ -2,6 +2,8 @@ import { $ } from "bun";
 
 const dry = process.argv.includes("--dry");
 
+const $noThrow = new $.Shell().env(process.env).nothrow();
+
 for (const file of new Bun.Glob("*").scanSync("metadata")) {
   const provider = await import(`./metadata/${file}`);
   const version = [provider.version, provider.suffix].filter(Boolean).join("-");
@@ -13,7 +15,7 @@ for (const file of new Bun.Glob("*").scanSync("metadata")) {
   }
   console.log("generating", name, "version", version);
   const result =
-    await $`pulumi package add terraform-provider ${provider.terraform} ${provider.version}`;
+    await $noThrow`pulumi package add terraform-provider ${provider.terraform} ${provider.version}`;
   const path = result.stdout
     .toString()
     .match(/at (\/[^\n]+)/)

--- a/metadata/singlestore.toml
+++ b/metadata/singlestore.toml
@@ -1,0 +1,3 @@
+name = "singlestore"
+terraform = "registry.terraform.io/singlestore-labs/singlestoredb"
+version = "0.1.0-alpha.10"


### PR DESCRIPTION
This adds the Terraform provider for [SingleStore](https://registry.terraform.io/providers/singlestore-labs/singlestoredb/latest).

I also resolved a potential build error that I found while testing this PR. The problem was that generate.ts would fail for the SingleStore provider because the provider's postinstall script runs with `pulumi package add` before the tsconfig is updated. To fix this, I created a separate shell instance with the `nothrow` option enabled and used that to run Pulumi commands. Other commands still run through the default shell, so they'll still throw.