### PR TITLE
feat: add hetzner-dns provider

### DIFF
--- a/metadata/hetzner.toml
+++ b/metadata/hetzner.toml
@@ -1,0 +1,3 @@
+name = "hetzner"
+terraform = "registry.terraform.io/opsheaven/hetzner"
+version = "0.2.0"

--- a/metadata/hetzner.toml
+++ b/metadata/hetzner.toml
@@ -1,3 +1,3 @@
-name = "hetzner"
+name = "hetzner-dns"
 terraform = "registry.terraform.io/opsheaven/hetzner"
 version = "0.2.0"


### PR DESCRIPTION
A provider for hetzner that allows to edit dns records. hcloud does not support this.