### PR TITLE
feat: add propel provider

### DIFF
--- a/metadata/propel.toml
+++ b/metadata/propel.toml
@@ -1,0 +1,3 @@
+name = "propel"
+terraform = "registry.terraform.io/propeldata/propel"
+version = "1.3.5"


### PR DESCRIPTION
Adds a provider for propel, a serverless Clickhouse DB: https://www.propeldata.com/