### PR TITLE
Add Statsig

### DIFF
--- a/metadata/statsig.toml
+++ b/metadata/statsig.toml
@@ -1,0 +1,3 @@
+name = "statsig"
+terraform = "registry.terraform.io/statsig-io/statsig"
+version = "2.0.0"


### PR DESCRIPTION
Statsig is a feature flag and experimentation platform. 

Landing page: https://statsig.com/
Terraform provider: https://registry.terraform.io/providers/statsig-io/statsig/2.0.0