### PR TITLE
feat: Add Bunnynet provider

### DIFF
--- a/metadata/bunnynet.toml
+++ b/metadata/bunnynet.toml
@@ -1,0 +1,3 @@
+name = "bunnynet"
+terraform = "BunnyWay/bunnynet"
+version = "0.8.0"


### PR DESCRIPTION
Bunny.net is a global edge platform that offers a fast, reliable, and often more cost-effective alternative to CloudFront.

Landing page: https://bunny.net/
Terraform provider: https://registry.terraform.io/providers/BunnyWay/bunnynet/0.8.0